### PR TITLE
Update quickstart-python3-native-firstquery-cb65.adoc

### DIFF
--- a/modules/quick-start/pages/quickstart-python3-native-firstquery-cb65.adoc
+++ b/modules/quick-start/pages/quickstart-python3-native-firstquery-cb65.adoc
@@ -87,14 +87,14 @@ user0001 = {
 user0002 = {
     "firstName" : "Major",
     "lastName" : "Tom",
-    "email" : "major.tom@acme.com(opens in new tab)",
+    "email" : "major.tom@acme.com",
     "tagLine" : "Send me up a drink",
     "type" : "user"
 }
 user0003 = {
     "firstName" : "Jerry",
     "lastName" : "Wasaracecardriver",
-    "email" : "jerry.wasaracecardriver@acme.com(opens in new tab)",
+    "email" : "jerry.wasaracecardriver@acme.com",
     "tagLine" : "el sob number one",
     "type" : "user"
 }
@@ -182,14 +182,14 @@ print (rv)
 user0002 = {
     "firstName" : "Major",
     "lastName" : "Tom",
-    "email" : "major.tom@acme.com(opens in new tab)",
+    "email" : "major.tom@acme.com",
     "tagLine" : "Send me up a drink",
     "type" : "user"
 }
 user0003 = {
     "firstName" : "Jerry",
     "lastName" : "Wasaracecardriver",
-    "email" : "jerry.wasaracecardriver@acme.com(opens in new tab)",
+    "email" : "jerry.wasaracecardriver@acme.com",
     "tagLine" : "el sob number one",
     "type" : "user"
 }


### PR DESCRIPTION
Removed the following text at four places:
(opens at new tab)
Because this statement is present, results are not coming correctly in the output. After removing this the the results are showing 3 rows as expected.