### PR TITLE
DOC-8773: Java 3 quickstart: use LIKE instead of =

### DIFF
--- a/modules/quick-start/pages/common/quickstart-java3.adoc
+++ b/modules/quick-start/pages/common/quickstart-java3.adoc
@@ -171,7 +171,7 @@ Finally, here is how you query the database when you need all users where the *e
 [source,Java]
 ----
     QueryResult result = cluster.query(
-            "SELECT * FROM `" + bucketName + "` WHERE email = $email",
+            "SELECT * FROM `" + bucketName + "` WHERE email LIKE $email",
             QueryOptions.queryOptions().parameters(JsonObject.create().put("email", "%@acme.com"))
     );
 


### PR DESCRIPTION
The last example of step 4 does the query `SELECT * FROM bucketName WHERE email = $email`, but then runs it with the parameters `{"email": "%@acme.com"}`. This returns no results, as the correct query would be `SELECT * FROM bucketName WHERE email LIKE $email`. This PR corrects the example.